### PR TITLE
[TR] TXM-3192 Capture the request path for play-auditing

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
+++ b/src/main/scala/uk/gov/hmrc/play/connectors/Connector.scala
@@ -18,20 +18,27 @@ package uk.gov.hmrc.play.connectors
 
 import play.api.libs.ws.{WS, WSRequest}
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.HeaderCarrierConverter
 
 trait RequestBuilder {
   def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest
 }
 
+object RequestBuilder {
+  def headers(hc: HeaderCarrier): Seq[(String,String)] = {
+    hc.headers.filter { case (name,value) => name != HeaderCarrierConverter.Path }
+  }
+}
+
 trait PlayWSRequestBuilder extends RequestBuilder {
 
   import play.api.Play.current
-  def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest = WS.url(url).withHeaders(hc.headers: _*)
+  def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest = WS.url(url).withHeaders(RequestBuilder.headers(hc): _*)
 }
 
 trait WSClientRequestBuilder extends RequestBuilder {
   this: WSClientProvider =>
-  def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest = client.url(url).withHeaders(hc.headers: _*)
+  def buildRequest(url: String)(implicit hc: HeaderCarrier): WSRequest = client.url(url).withHeaders(RequestBuilder.headers(hc): _*)
 }
 
 @deprecated("Please use PlayWSRequestBuilder instead", "3.1.0")

--- a/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/connectors/ConnectorSpec.scala
@@ -55,7 +55,8 @@ class ConnectorSpec extends WordSpecLike with Matchers {
           forwarded     = Some(forwarded),
           sessionId     = Some(sessionId),
           requestId     = Some(requestId),
-          deviceID      = Some(deviceID)
+          deviceID      = Some(deviceID),
+          otherHeaders  = Seq("path" -> "/the/request/path")
         )
 
         val request = p.builder.buildRequest("authBase")(carrier)
@@ -65,6 +66,7 @@ class ConnectorSpec extends WordSpecLike with Matchers {
         request.headers.get(HeaderNames.xSessionId).flatMap(_.headOption)    shouldBe Some(sessionId.value)
         request.headers.get(HeaderNames.xRequestId).flatMap(_.headOption)    shouldBe Some(requestId.value)
         request.headers.get(HeaderNames.deviceID).flatMap(_.headOption)      shouldBe Some(deviceID)
+        request.headers.get("path")                                          shouldBe None
       }
     }
   }

--- a/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/http/HeaderCarrierSpec.scala
@@ -170,6 +170,15 @@ class HeaderCarrierSpec extends WordSpecLike with Matchers {
         .otherHeaders shouldBe Seq("X-Client-ID" -> "foo")
     }
 
+    "add the request path" in running(FakeApplication()) {
+      HeaderCarrierConverter
+        .fromHeadersAndSessionAndRequest(
+          headers(),
+          request = Some(new DummyRequestHeader() { override def path ="/the/request/path"} )
+        )
+        .otherHeaders shouldBe Seq("path" -> "/the/request/path")
+    }
+
   }
 
   "build Google Analytics headers from request" should {


### PR DESCRIPTION
Adds the request path to HeaderCarrier so that play auditing can
include it in audits without requiring developers to explicitly
pass through the request path to the audit call and without
adding play as a play-auditing dependency.

Despite the name, play-auditing no longer depends on play.
It will be renamed to auditing as part of the play-2.6 upgrade.

The path is added to 'otherHeaders' rather than a new field in
HeaderCarrier to avoid changing HeaderCarrier. HeaderCarrier is
in the http-core library which now depends on play-2.6 so a
change to HeaderCarrier would require consumers to upgrade to
play-2.6